### PR TITLE
Fix chromium not starting on balenaOS  v2.83.6+

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# this allows chromium sandbox to run, see https://github.com/balena-os/meta-balena/issues/2319
+sysctl -w user.max_user_namespaces=10000
+
 # Run balena base image entrypoint script
 /usr/bin/entry.sh echo "Running balena base image entrypoint..."
 


### PR DESCRIPTION
[balenaOS v2.83.6](https://github.com/balena-os/meta-balena/blob/master/CHANGELOG.md#v2836) enables user namespacing by default, making applications such as chromium unable to run.
We override the kernel parameter `user.max_user_namespaces` in the application as a workaround.

Fixes #77 

Change-type: patch
Signed-off-by: Rahul Thakoor <rahul@balena.io>