### PR TITLE
Make rotation delay configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ The following environment variables allow configuration of the `browser` block:
 |`EXTRA_FLAGS`|[many!](https://peter.sh/experiments/chromium-command-line-switches/)|N/A|Adds **additional** flags chromium is started with. Enter a space (\' \') separated list of flags (e.g. `--audio-buffer-size=2048 --audio-output-channels=8`)|
 |`PERSISTENT`|`0`, `1`|`0`|Enables/disables user profile data being stored on the device. **Note: you'll need to create a settings volume. See example above** <br/> `0` = off, `1` = on|
 |`ROTATE_DISPLAY`|`normal`, `left`, `right`, `inverted`|`normal`|Rotates the display|
+|`ROTATE_DELAY`|`n`|`3`|Add an artificial delay (in seconds) before applying display rotation|
 |`TOUCHSCREEN`|`string`|N\A|Name of Touch Input to rotate|
 |`ENABLE_GPU`|`0`, `1`|0|Enables the GPU rendering. Necessary for Pi3B+ to display YouTube videos. <br/> `0` = off, `1` = on|
 |`WINDOW_SIZE`|`x,y`|Detected screen resolution|Sets the browser window size, such as `800,600`. <br/> **Note:** Reverse the dimensions if you also rotate the display to `left` or `right` |

--- a/src/startx.sh
+++ b/src/startx.sh
@@ -38,7 +38,9 @@ fi
 
 # rotate screen if env variable is set [normal, inverted, left or right]
 if [[ ! -z "$ROTATE_DISPLAY" ]]; then
-  sleep 3 && xrandr -o $ROTATE_DISPLAY
+  ROTATE_DELAY="${ROTATE_DELAY:-3}"
+
+  sleep "$ROTATE_DELAY" && xrandr -o $ROTATE_DISPLAY
 
   #If the display is rotated to left or right, we need to reverse the size and position coords
   if [[ "$ROTATE_DISPLAY" == "left" ]] || [[ "$ROTATE_DISPLAY" == "right" ]]; then


### PR DESCRIPTION
At this point we hardcode a 3 seconds delay before applying display rotation, which on some systems is not enough, while on other systems it is too much.

This patch exposes a `ROTATE_DELAY` variable that makes the delay configurable.