### PR TITLE
Added commands to enable/disable display via management API

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "humao.rest-client"
+    ]
+}

--- a/browser-management-api-requests.http
+++ b/browser-management-api-requests.http
@@ -1,0 +1,94 @@
+# This file can be used with the VSCode Rest Client extension (https://marketplace.visualstudio.com/items?itemName=humao.rest-client) to play with the browser block API.
+@baseUrl=http://your-device-hostname:5011
+
+### Ping the browser block
+GET {{baseUrl}}/ping
+
+### Refresh the currently displayed page
+POST {{baseUrl}}/refresh
+
+### Automatically refresh the browser window every 30 seconds
+POST {{baseUrl}}/autorefresh/30
+
+### Disable automatic refresh
+POST {{baseUrl}}/autorefresh/0
+
+### Re-scan for local HTTP or HTTPS services
+POST {{baseUrl}}/scan
+
+### Get the URL currently being displayed
+GET {{baseUrl}}/url
+
+### Set the URL to be displayed
+PUT {{baseUrl}}/url
+Content-Type: application/x-www-form-urlencoded
+
+url=http://www.balena.io
+
+### Set the URL with GPU and Kiosk settings
+PUT {{baseUrl}}/url
+Content-Type: application/x-www-form-urlencoded
+
+url=http://www.balena.io&gpu=1&kiosk=1
+
+### Get the status of the GPU
+GET {{baseUrl}}/gpu
+
+### Enable the GPU
+PUT {{baseUrl}}/gpu/1
+
+### Disable the GPU
+PUT {{baseUrl}}/gpu/0
+
+### Get the status of Kiosk mode
+GET {{baseUrl}}/kiosk
+
+### Enable Kiosk mode
+POST {{baseUrl}}/kiosk/1
+
+### Disable Kiosk mode
+POST {{baseUrl}}/kiosk/0
+
+### Get the flags Chromium was started with
+GET {{baseUrl}}/flags
+
+### Get the version of Chromium
+GET {{baseUrl}}/version
+
+### Take a screenshot of the Chromium window
+GET {{baseUrl}}/screenshot
+
+### Get the display state
+GET {{baseUrl}}/display
+
+### Set the display state to on
+POST {{baseUrl}}/display
+Content-Type: application/json
+
+{
+  "state": "on"
+}
+
+### Set the display state to off
+POST {{baseUrl}}/display
+Content-Type: application/json
+
+{
+  "state": "off"
+}
+
+### Set the display state to on using PUT
+PUT {{baseUrl}}/display
+Content-Type: application/json
+
+{
+  "state": "on"
+}
+
+### Set the display state to off using PUT
+PUT {{baseUrl}}/display
+Content-Type: application/json
+
+{
+  "state": "off"
+}

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ The block provides an API for dynamic configuration, and also exposes the Chromi
 - Automatically displays local HTTP (port 80 or 8080) or HTTPS (443) service endpoints.
 - API for remote configuration and management
 - Chromium remote debugging port
+- Remotely enable/disable display
 ---
 
 ## Usage
@@ -220,6 +221,24 @@ Returns the version of Chromium that `browser` is running
 #### **GET** /screenshot
 Uses [scrot](https://opensource.com/article/17/11/taking-screen-captures-linux-command-line-scrot) to take a screenshot of the chromium window. 
 The screenshot will be saved as a temporary file in the container.
+
+
+#### **GET** /display
+Returns `on` or `off` depending on the display status
+
+#### **PUT** or **POST** /display
+Expects json payload with `state` key. 
+
+Turn display on:
+```bash
+curl -X PUT -H "Content-Type: application/json" -d '{"state": "on"}' http://localhost:5011/display
+```
+
+Turn display off:
+```bash
+curl -X PUT -H "Content-Type: application/json" -d '{"state": "off"}' http://localhost:5011/display
+```
+
 
 ---
 


### PR DESCRIPTION
Added a `/display` resource with GET, PUT, POST support to disable/enable the display via `xset dpms force off/on`. 
Also added a `.http` file to easily make requests to the block via the [REST client VSCode extension.](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)