### PR TITLE
Remove balenalib and dependencies

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
-ARG NODEJS_VERSION="20.12.0"
+FROM node:20.19.2-bookworm
 
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:${NODEJS_VERSION}-bookworm-run
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install the necessary packages
 COPY ./build /usr/src/build

--- a/build/install_chromium
+++ b/build/install_chromium
@@ -34,7 +34,8 @@ else
     ln -s /usr/bin/chromium /usr/bin/chromium-browser
 fi
 
-install_packages \
+#install_packages \
+apt-get update && apt-get install -y \
     ${CHROMIUM_PACKAGE} \
     chromium-common \
     libgles2-mesa \

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -1,0 +1,50 @@
+#ARG NODEJS_VERSION="20.12.0"
+
+ARG NODEJS_VERSION="20.19.2"
+
+#FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:${NODEJS_VERSION}-bookworm-run
+
+FROM node:20.19.2-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install the necessary packages
+COPY ./build /usr/src/build
+RUN chmod a+x /usr/src/build/install_chromium
+RUN /usr/src/build/install_chromium "%%BALENA_MACHINE_NAME%%"
+
+WORKDIR /usr/src/app
+
+# install node dependencies
+COPY ./package.json /usr/src/app/package.json
+RUN JOBS=MAX npm install --unsafe-perm --production && npm cache clean --force
+
+COPY ./src /usr/src/app/
+
+RUN chmod +x ./*.sh
+
+ENV UDEV=1
+
+RUN mkdir -p /etc/chromium/policies
+RUN mkdir -p /etc/chromium/policies/recommended
+COPY ./policy.json /etc/chromium/policies/recommended/my_policy.json
+
+# Add chromium user
+RUN useradd chromium -m -s /bin/bash -G root || true && \
+    groupadd -r -f chromium && id -u chromium || true \
+    && chown -R chromium:chromium /home/chromium || true
+
+COPY ./public-html /home/chromium  
+
+# udev rule to set specific permissions 
+RUN echo 'SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"' > /etc/udev/rules.d/10-vchiq-permissions.rules
+RUN usermod -a -G audio,video,tty chromium
+
+# Set up the audio block. This won't have any effect if the audio block is not being used.
+RUN curl -skL https://raw.githubusercontent.com/balena-labs-projects/audio/master/scripts/alsa-bridge/debian-setup.sh| sh
+ENV PULSE_SERVER=tcp:audio:4317
+
+COPY VERSION .
+
+# Start app
+CMD ["bash", "/usr/src/app/start.sh"]

--- a/src/start.sh
+++ b/src/start.sh
@@ -4,7 +4,7 @@
 sysctl -w user.max_user_namespaces=10000
 
 # Run balena base image entrypoint script
-/usr/bin/entry.sh echo "Running balena base image entrypoint..."
+/usr/src/app/entry.sh echo "Running balena base image entrypoint..."
 
 export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
@@ -68,4 +68,5 @@ environment="${environment::-1}"
 
 # launch Chromium and whitelist the enVars so that they pass through to the su session
 su -w $environment -c "export DISPLAY=:$DISPLAY_NUM && startx /usr/src/app/startx.sh $CURSOR" - chromium
-balena-idle
+#balena-idle
+sleep infinity


### PR DESCRIPTION
This PR changes the base image from balenalib to the official node image.

Other features/files that depend on balenalib have also been updated.

Tested on Pi 3b+, 4, 5, and x86.