### PR TITLE
Make this block usable on Raspberry Pi Zero 2 W

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -28,9 +28,17 @@ RUN useradd chromium -m -s /bin/bash -G root || true && \
     groupadd -r -f chromium && id -u chromium || true \
     && chown -R chromium:chromium /home/chromium || true
 
-COPY ./public-html /home/chromium  
+COPY ./public-html /home/chromium
 
-# udev rule to set specific permissions 
+# rpi-zero2w can't handle the Javascript libraries loaded
+# in ./public-html/index.html so on this device only we
+# patch /home/chromium/index.html to comment the relevant
+# <script> elements out
+RUN chmod a+x /usr/src/build/lowmem_patch_html
+RUN /usr/src/build/lowmem_patch_html "%%BALENA_MACHINE_NAME%%"
+
+
+# udev rule to set specific permissions
 RUN echo 'SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"' > /etc/udev/rules.d/10-vchiq-permissions.rules
 RUN usermod -a -G audio,video,tty chromium
 

--- a/build/lowmem_patch_html
+++ b/build/lowmem_patch_html
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# install_chromium uses MACHINE_NAME passed in from the Dockerfile
+# to identify the hardware
+# We could use $BALENA_DEVICE_TYPE which is also defined in the
+# script and would not need to be passed in
+# Not sure why install_chromium did it this way, but following
+# that convention until I understand
+MACHINE_NAME="$1"
+
+# The balenalibs source file public-html/index.html loads
+# jquery and bootstrap Javascript libraries as well as some
+# custom Javascript related to navigation.
+# On rpi-zero2w, it looks like the Javascript
+# is just too much for browser to handle given the constrained
+# memory on that device.  The page comes up white and nothing
+# renders.
+# If we edit out the four <script> elements appearing after the
+# <footer> element of the page, the page appears to render fine
+# without them.
+
+# Note that the rpi-zero2w with 0.5Gbyte RAM is not really a
+# suitable device for running Chromium due to the low memory
+# - the /usr/bin/chromium{-browser} wrapper script requires
+# an argument --no-memcheck to allow Chromium to start without
+# the user acknowledging a dialog box notifying that
+# trying to run with less than 1Gbyte RAM is a bad idea.
+
+if [ "$MACHINE_NAME" = "raspberrypi0-2w-64" ]
+then
+  echo Patching index.html to remove Javascript elements
+  sed -e "s^Bootstrap core JavaScript^raspberrypi0-2w-64 can't run jquery^" -i /home/chromium/index.html
+  sed -e 's^<script^<!-- script^' -i /home/chromium/index.html
+  sed -e 's^script>^/script -->^' -i /home/chromium/index.html
+  echo Patch completed
+else
+  echo No need to patch index.html to remove Javascript elements
+fi

--- a/src/start.sh
+++ b/src/start.sh
@@ -44,14 +44,31 @@ then
 	fi
 fi
 
-# Inject X11 config on the RPi 5 as the defaults do not work
-# We do this in the startup script and only for the RPi 5 because
-# we build the images per-architecture and we do not want to break
-# other aarch64-based device types
 if [ "${BALENA_DEVICE_TYPE}" = "raspberrypi5" ]
 then
+    # Inject X11 config on the RPi 5 as the defaults do not work
+    # We do this in the startup script and only for the RPi 5 because
+    # we build the images per-architecture and we do not want to break
+    # other aarch64-based device types
     echo "Raspberry Pi 5 detected, injecting X.org config"
     cp -a "/usr/src/build/rpi/99-vc4.conf" "/etc/X11/xorg.conf.d/"
+elif [ "${BALENA_DEVICE_TYPE}" = "raspberrypi0-2w-64" ]
+then
+    # The low memory warning which the chromium wrapper script generates 
+    # on this platform can't be dismissed if the device is being used
+    # as a display kiosk only and doesn't have a mouse/pointer device 
+    # attached
+    echo "Disabling low memory warning (always triggers on ${BALENA_DEVICE_TYPE})"
+    if [ -z "$EXTRA_FLAGS" ]
+    then
+        export EXTRA_FLAGS="--no-memcheck"
+    else
+        # insert --no-memcheck before the content of EXTRA_FLAGS 
+        # passed in from the docker-compose.yml environment so 
+        # that --memcheck will be honoured if the author of the 
+        # docker-compose.yml chooses to specify it there
+        export EXTRA_FLAGS="--no-memcheck $EXTRA_FLAGS"
+    fi
 fi
 
 # set up the user data area
@@ -69,3 +86,4 @@ environment="${environment::-1}"
 # launch Chromium and whitelist the enVars so that they pass through to the su session
 su -w $environment -c "export DISPLAY=:$DISPLAY_NUM && startx /usr/src/app/startx.sh $CURSOR" - chromium
 balena-idle
+

--- a/src/startx.sh
+++ b/src/startx.sh
@@ -77,7 +77,13 @@ sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' /data/chromium/'Local S
 sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"/"exit_type":"Normal"/' /data/chromium/Default/Preferences > /dev/null 2>&1 || true 
 
 # Set chromium version into an EnVar for later
-export VERSION=`chromium-browser --version`
+# We need to include --no-memcheck in the command line in
+# case we are on a low memory device where the chromium-browser
+# wrapper script would block the command from running until
+# the user acknowledged a low memory dialog on the X screen
+# (in kiosk mode, without an input pointer device it is
+# not possible to dismiss this warning).
+export VERSION=`chromium-browser --no-memcheck --version`
 echo "Installed browser version: $VERSION"
 
 # stop the screen blanking


### PR DESCRIPTION
There are two impediments which prevent this block from running usefully on on RPi-Zero2W:

- The wrapper script /usr/bin/chromium will always present a modal dialog warning that the 0.5 GByte memory of this board is less than the 1G recommended minimum for Chromium to run.   If the device has an attached mouse or pointer device this can be dismissed by the user (it needs to be dismissed twice because the wrapper is run to capture the Chromium version number before it is run as a full browser).  This is ugly enough, but if the device is being run in a display-only application where the user does not have a mouse/pointer there is no way of dismissing the dialog and the intended content will never be displayed.
- The source file public-html/index.html which gets installed into /home/chromium includes <script> elements which load the Bootstrap and JQuery Javascript libraries, and with these loaded the limited memory is presumably exhausted and no content is displayed (leaving the screen white).

The two commits in this PR address these impediments by:
- modifying the start.sh and startx.sh scripts to ensure that, on this hardware only, additional argument --no-memcheck is included both times /usr/bin/chromium is run.
- adding an additional script running during the docker build which, on this hardware only, patches /home/chromium/index.html to comment out the <script> elements which load the large Javascript libraries.

Although this patch was built against the browser-2.10, based on the obsolete balenalib base image, they were originally developed against a branch updated to reflect the changes in pull request #185 which, when merged, will update this  to use generic docker images.  I believe that these changes are orthogonal to the changes required for #185, and it is unlikely to matter which of the two is merged first.

Of course whether the maintainers choose to accept this patch will also depend on whether they consider operability on this low resource device to be worth supporting.  Experiments I have done here suggest that the device can cope with moderately complex static HTML5/CSS (e.g. copying pages generated from RST using sphinx styling), and can also handle very simple Javascript operations on the DOM of the page, but not heavyweight Javascript libraries).
